### PR TITLE
Update _config.ts markdownemoji

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -6,7 +6,7 @@ import codeHighlight from "lume/plugins/code_highlight.ts";
 import basePath from "lume/plugins/base_path.ts";
 import slugifyUrls from "lume/plugins/slugify_urls.ts";
 import resolveUrls from "lume/plugins/resolve_urls.ts";
-import markdownEmoji from "https://jspm.dev/markdown-it-emoji";
+import { full as markdownEmoji } from "https://jspm.dev/markdown-it-emoji";
 import gpm from "https://deno.land/x/gpm@v0.5.0/mod.ts";
 import netlifyCMS from "lume/plugins/netlify_cms.ts";
 import generatePdf from "./eventHandlers/generatePdf.ts";


### PR DESCRIPTION
Currently it is giving this error

SyntaxError: The requested module 'https://jspm.dev/markdown-it-emoji' does not provide an export named 'markdownEmoji' at file:///Users/ca/dev/denissb.github.io/_config.ts:9:10
    at async createSite (https://deno.land/x/lume@v1.18.4/cli/run.ts:50:17)
    at async build (https://deno.land/x/lume@v1.18.4/cli/build.ts:33:16)
    at async Command.execute (https://deno.land/x/cliffy@v0.25.7/command/command.ts:1794:7)
    at async Command.parseCommand (https://deno.land/x/cliffy@v0.25.7/command/command.ts:1639:14)
    at async (https://deno.land/x/lume@v1.18.4/cli.ts:135:3)